### PR TITLE
grub.cfg: allow customizing the menuentry via a new "snap_menuentry"

### DIFF
--- a/grub.cfg
+++ b/grub.cfg
@@ -8,6 +8,11 @@ if [ -s $prefix/grubenv ]; then
   load_env
 fi
 
+# allow customizing the menu entry via grubenv
+if [ -z "$snap_menuentry" ]; then
+    set snap_menuentry="Ubuntu Core 16"
+fi
+
 if [ "$snap_mode" = "try" ]; then
     # a new core or kernel got installed
     set snap_mode="trying"
@@ -29,7 +34,7 @@ fi
 set label="writable"
 set cmdline="root=LABEL=$label snap_core=$snap_core snap_kernel=$snap_kernel ro net.ifnames=0 init=/lib/systemd/systemd console=ttyS0 console=tty1 panic=-1"
 
-menuentry "Ubuntu Core 16" {
+menuentry "$snap_menuentry" {
     search --label $label --set=writable
     loopback loop ($writable)/system-data/var/lib/snapd/snaps/$snap_kernel
     linux (loop)/kernel.img $cmdline


### PR DESCRIPTION
This is the i386 version of https://github.com/snapcore/pc-amd64-gadget/pull/7